### PR TITLE
Refurb enhance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 # How to Create a Proper Reproduction
 
+Create a minimal reproduction that is immediately deployable and demonstrates the behavior in question.
+
 Reference: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2337
+
+## Getting Started
+
+1. Fork and Clone this repo
+2. Update these variables in `main.tf`: (last updated 2024-30-01)
+    - Anything in `locals`
+    - Module Version numbers, and
+    - `eks_blueprints_addons` in `helm-test.tf` if necessary
+3. Run `terraform init -get=true && terraform apply -auto-approve`; takes ~12 minutes to build
+4. Get the kubeconfig file for testing, et al.:
+
+     `aws eks update-kubeconfig --name <cluster_name> --region <region>`
+5. Push to your forked repo
+6. Collect relevant details: outputs, logging, etc.
+7. Provide those details and a link to your forked repo in the issue
+
+---
 
 ## Why is it "Proper"?
 
@@ -10,4 +29,4 @@ Reference: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/233
 
 ## Why is it NOT "Proper"?
 
-- It does not reproduce the error referenced, but that was the intent of this - to show others what a reproduction *should* look like so that they can modify to demonstrate the behavior that plagues them or they deem undesirable. Once we have this, we can engage in a great discussion as to whether this is by design or whether there is a flaw in the module that should be corrected/addressed.
+- It does not reproduce the error referenced, but that was the intent of this - to show others what a reproduction *should* look like so that they can modify to demonstrate the behavior that plagues them, or they deem undesirable. Once we have this, we can discuss whether this is by design or there is a flaw in the module that should be corrected/addressed.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Reference: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/233
 6. Collect relevant details: outputs, logging, etc.
 7. Provide those details and a link to your forked repo in the issue
 
+When done:
+
+`terraform apply -destroy -auto-approve`
+
 ---
 
 ## Why is it "Proper"?

--- a/helm-test.tf
+++ b/helm-test.tf
@@ -1,9 +1,18 @@
-################################################################################
-# TEST Cluster COMMs by deploying the Metrics Server Addon
-################################################################################
+/*
+  ----------------------------------------------------------------------------------------------------------------------
+  TEST Cluster COMMs by deploying the Metrics Server Addon
+  https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/releases
+  ----------------------------------------------------------------------------------------------------------------------
+*/
+
 #module "eks_blueprints_addons" {
 #  source  = "aws-ia/eks-blueprints-addons/aws"
-#  version = "~> 1.12.0" #ensure to update this to the latest/desired version
+#  version = "~> 1.13.0" # update to the latest/desired version
 #
-#  enable metrics_server = true
+#  enable_metrics_server = true
+#
+#  cluster_name      = module.eks.cluster_name
+#  cluster_endpoint  = module.eks.cluster_endpoint
+#  cluster_version   = module.eks.cluster_version
+#  oidc_provider_arn = module.eks.oidc_provider_arn
 #}

--- a/helm-test.tf
+++ b/helm-test.tf
@@ -1,0 +1,9 @@
+################################################################################
+# TEST Cluster COMMs by deploying the Metrics Server Addon
+################################################################################
+#module "eks_blueprints_addons" {
+#  source  = "aws-ia/eks-blueprints-addons/aws"
+#  version = "~> 1.12.0" #ensure to update this to the latest/desired version
+#
+#  enable metrics_server = true
+#}

--- a/karpenter/node-pool-apps.yaml
+++ b/karpenter/node-pool-apps.yaml
@@ -1,0 +1,44 @@
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["spot"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
+      nodeClassRef:
+        name: default
+  limits:
+    cpu: 1000
+  disruption:
+    consolidationPolicy: WhenUnderutilized
+    expireAfter: 720h # 30 * 24h = 720h
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: default
+spec:
+  amiFamily: AL2 # Amazon Linux 2
+  role: "karpenter-reproduction-20240126165825434100000005"
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "reproduction"
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "reproduction"

--- a/karpenter/test/pause.yaml
+++ b/karpenter/test/pause.yaml
@@ -1,0 +1,22 @@
+# Deploy pause service for Testing/Demos
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inflate
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: inflate
+  template:
+    metadata:
+      labels:
+        app: inflate
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+        - name: inflate
+          image: public.ecr.aws/eks-distro/kubernetes/pause:3.7
+          resources:
+            requests:
+              cpu: 1

--- a/main.tf
+++ b/main.tf
@@ -145,9 +145,9 @@ resource "aws_iam_role" "this" {
 
 resource "aws_iam_role_policy_attachment" "this" {
   for_each = { for k, v in toset([
-    "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
-    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
-    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+    "arn:${local.part}:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:${local.part}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+    "arn:${local.part}:iam::aws:policy/AmazonEKS_CNI_Policy"
   ]) : k => v }
 
   policy_arn = each.value

--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,8 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 locals {
-  name   = "reproduction"
-  region = "us-gov-east-1"
+  name        = "reproduction"
+  region      = "us-east-1"
   eks_version = "1.29"
 
   vpc_cidr = "10.0.0.0/16"
@@ -28,8 +28,9 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "19.21.0" # https://github.com/terraform-aws-modules/terraform-aws-eks/releases
 
-  cluster_name    = local.name
-  cluster_version = local.eks_version
+  cluster_name                   = local.name
+  cluster_version                = local.eks_version
+  cluster_endpoint_public_access = true
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,15 @@
+output "reproduction-region" {
+  value = local.region
+}
+
+output "reproduction-project" {
+  value = local.name
+}
+
+output "reproduction-account" {
+  value = data.aws_caller_identity.current.account_id
+}
+
+output "reproduction-part" {
+  value = local.part
+}


### PR DESCRIPTION
There were a lot of changes in here:

- `main.tf` : restructured file so:
  - parameters that need to be changed more frequently are towards the top
  - parameters that need to be changed less frequently are towards the bottom
 - added plumbing for addons comms with the cluster
 - added test for those comms (commented until needed)
 - added discovery/use of `${local.part}` so a reproduction can run in any AWS partition
 - added `outputs.tf` for conveniences to be added later
 - updated versions for all modules
 - enabled public eks endpoint for easier collection of cluster details/logs/etc
 - updated `README.md` with explicit steps.

